### PR TITLE
Vaclav: use active_players instead of changing corporation owner

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2581,9 +2581,20 @@ module Engine
 
         def active_players
           active = super
-          return active if multiplayer?
+          return active if active != [@vaclav]
 
-          active.reject { |item| item == @vaclav }
+          case active_step
+          when G18CZ::Step::Track
+            current_entity.type == 'medium' ? [players_without_vaclav[1]] : [players_without_vaclav[0]]
+          when G18CZ::Step::Token
+            current_entity.type == 'medium' ? [players_without_vaclav[0]] : [players_without_vaclav[1]]
+          else
+            players_without_vaclav
+          end
+        end
+
+        def valid_actors(action)
+          action.entity.player == @vaclav ? active_players : super
         end
 
         def optional_hexes
@@ -2617,11 +2628,6 @@ module Engine
         end
 
         def operating_round(round_num)
-          unless multiplayer?
-            track_lay_player = player_of_index(1)
-            @vaclavs_corporations.each { |item| item.owner = track_lay_player }
-          end
-
           G18CZ::Round::Operating.new(self, [
             G18CZ::Step::HomeTrack,
             G18CZ::Step::SellCompanyAndSpecialTrack,
@@ -2714,7 +2720,6 @@ module Engine
           else
             # cloning is needed because vaclavs corporation changes when a new train triggers a new corporation
             @vaclavs_corporations.clone.each do |item|
-              item.owner = @vaclav
               new_train_for_vaclav(item)
             end
           end

--- a/lib/engine/game/g_18_cz/step/track.rb
+++ b/lib/engine/game/g_18_cz/step/track.rb
@@ -18,9 +18,6 @@ module Engine
           def pass!
             super
             @game.track_action_processed(current_entity)
-            return unless @game.corporation_of_vaclav?(current_entity)
-
-            current_entity.owner = @game.player_of_index(0)
           end
         end
       end


### PR DESCRIPTION
tested with small and medium companies

* priority player does small track and medium token
* second player does medium track and small token
* both players can do the route for small and medium
* entities tab always lists Vaclav's corporations under Vaclav

There are still some quirks to work out, like the log showing "The Bank" as laying the track or the "Next SR" player order counts still including Vaclav, but I think it's alpha-playable by the rules with these changes.